### PR TITLE
Add reload command and config options

### DIFF
--- a/src/main/java/com/AJgorEx/xFlyPlot/Main.java
+++ b/src/main/java/com/AJgorEx/xFlyPlot/Main.java
@@ -5,17 +5,29 @@ import com.AJgorEx.xFlyPlot.listeners.BlockBreakListener;
 import com.AJgorEx.xFlyPlot.listeners.VoidFallListener;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import java.util.Objects;
+
 public class Main extends JavaPlugin {
 
     private OneBlockManager manager;
 
     @Override
     public void onEnable() {
+        saveDefaultConfig();
+
         manager = new OneBlockManager(this);
-        getCommand("oneblock").setExecutor(new OneBlockCommand(manager));
+        Objects.requireNonNull(getCommand("oneblock")).setExecutor(new OneBlockCommand(manager));
         getServer().getPluginManager().registerEvents(new BlockBreakListener(manager), this);
         getServer().getPluginManager().registerEvents(new VoidFallListener(manager), this);
+
         getLogger().info("xFlyPlot enabled.");
+    }
+
+    @Override
+    public void onDisable() {
+        if (manager != null) {
+            manager.clearAll();
+        }
     }
 
     public OneBlockManager getOneBlockManager() {

--- a/src/main/java/com/AJgorEx/xFlyPlot/OneBlockManager.java
+++ b/src/main/java/com/AJgorEx/xFlyPlot/OneBlockManager.java
@@ -30,6 +30,11 @@ public class OneBlockManager {
         loadPhases();
     }
 
+    public void reloadPhases() {
+        phases.clear();
+        loadPhases();
+    }
+
     public void startIsland(Player player) {
         UUID uuid = player.getUniqueId();
 
@@ -63,7 +68,8 @@ public class OneBlockManager {
                 .environment(World.Environment.NORMAL)
                 .type(WorldType.FLAT));
 
-        Location genLoc = new Location(world, 0, 64, 0);
+        int height = plugin.getConfig().getInt("height", 64);
+        Location genLoc = new Location(world, 0, height, 0);
 
         world.getBlockAt(genLoc).setType(Material.GRASS_BLOCK);
         world.getBlockAt(genLoc.clone().subtract(0, 1, 0)).setType(Material.BEDROCK);

--- a/src/main/java/com/AJgorEx/xFlyPlot/VoidChunkGenerator.java
+++ b/src/main/java/com/AJgorEx/xFlyPlot/VoidChunkGenerator.java
@@ -1,9 +1,7 @@
 package com.AJgorEx.xFlyPlot;
 
-import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.generator.ChunkGenerator;
-
 
 import java.util.Random;
 
@@ -12,15 +10,7 @@ public class VoidChunkGenerator extends ChunkGenerator {
     @Override
     @SuppressWarnings("deprecation")
     public ChunkData generateChunkData(World world, Random random, int chunkX, int chunkZ, BiomeGrid biome) {
-        ChunkData chunkData = createChunkData(world);
-        // Fill the chunk with air
-        for (int x = 0; x < 16; x++) {
-            for (int z = 0; z < 16; z++) {
-                for (int y = 0; y < world.getMaxHeight(); y++) {
-                    chunkData.setBlock(x, y, z, Material.AIR);
-                }
-            }
-        }
-        return chunkData;
+        // Return an empty chunk - Bukkit will fill it with air by default
+        return createChunkData(world);
     }
 }

--- a/src/main/java/com/AJgorEx/xFlyPlot/commands/OneBlockCommand.java
+++ b/src/main/java/com/AJgorEx/xFlyPlot/commands/OneBlockCommand.java
@@ -1,6 +1,7 @@
 package com.AJgorEx.xFlyPlot.commands;
 
 import com.AJgorEx.xFlyPlot.OneBlockManager;
+import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -21,8 +22,19 @@ public class OneBlockCommand implements CommandExecutor {
             return true;
         }
 
-        if (args.length > 0 && args[0].equalsIgnoreCase("home")) {
-            manager.teleportHome(p);
+        if (args.length > 0) {
+            switch (args[0].toLowerCase()) {
+                case "home" -> manager.teleportHome(p);
+                case "reload" -> {
+                    if (p.hasPermission("oneblock.reload")) {
+                        manager.reloadPhases();
+                        p.sendMessage(ChatColor.GREEN + "Plik phases.yml przeładowany.");
+                    } else {
+                        p.sendMessage(ChatColor.RED + "Brak uprawnień.");
+                    }
+                }
+                default -> manager.startIsland(p);
+            }
         } else {
             manager.startIsland(p);
         }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,3 @@
+# Default configuration for xFlyPlot OneBlock plugin
+# Height at which the generator block is created
+height: 64

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,10 +6,13 @@ author: AJgorEx
 description: Zaawansowany plugin OneBlock z własnym światem, bossbarem i fazami
 commands:
   oneblock:
-    description: Tworzy wyspę OneBlock lub teleportuje na nią
-    usage: /oneblock
+    description: Zarządza wyspą OneBlock
+    usage: /oneblock [home|reload]
     aliases: [ob, startblock]
 permissions:
   oneblock.use:
     description: Pozwala na używanie komendy /oneblock
     default: true
+  oneblock.reload:
+    description: Pozwala na przeładowanie faz
+    default: op


### PR DESCRIPTION
## Summary
- add configuration file and load generator height from it
- support phases reload via `/oneblock reload`
- cleanup bossbars on disable
- simplify void chunk generation

## Testing
- `./gradlew build` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_684499fb79fc832586355dcb2f1833c4