### PR TITLE
Add progress commands

### DIFF
--- a/src/main/java/com/AJgorEx/xFlyPlot/OneBlockManager.java
+++ b/src/main/java/com/AJgorEx/xFlyPlot/OneBlockManager.java
@@ -130,7 +130,7 @@ public class OneBlockManager {
         }
     }
 
-    private Phase getCurrentPhase(int blocksBroken) {
+    public Phase getCurrentPhase(int blocksBroken) {
         int sum = 0;
         for (Phase phase : phases) {
             sum += phase.getBlockCount();
@@ -191,5 +191,33 @@ public class OneBlockManager {
 
     public List<Phase> getPhases() {
         return Collections.unmodifiableList(phases);
+    }
+
+    public int getPlayerProgress(UUID uuid) {
+        return playerProgress.getOrDefault(uuid, 0);
+    }
+
+    public Phase getPlayerPhase(UUID uuid) {
+        return getCurrentPhase(getPlayerProgress(uuid));
+    }
+
+    public void sendProgress(Player player) {
+        UUID uuid = player.getUniqueId();
+        if (!playerGenerators.containsKey(uuid)) {
+            player.sendMessage(ChatColor.RED + "Nie masz jeszcze wyspy.");
+            return;
+        }
+        int progress = getPlayerProgress(uuid);
+        Phase phase = getCurrentPhase(progress);
+        player.sendMessage(ChatColor.YELLOW + "Faza: " + ChatColor.GOLD + phase.getName()
+                + ChatColor.GRAY + " [" + progress + "/" + phase.getBlockCount() + "]");
+    }
+
+    public void listPhases(Player player) {
+        player.sendMessage(ChatColor.YELLOW + "Dostępne fazy:");
+        for (Phase phase : phases) {
+            player.sendMessage(ChatColor.GRAY + "- " + ChatColor.GOLD + phase.getName()
+                    + ChatColor.GRAY + " (" + phase.getBlockCount() + ")");
+        }
     }
 }

--- a/src/main/java/com/AJgorEx/xFlyPlot/commands/OneBlockCommand.java
+++ b/src/main/java/com/AJgorEx/xFlyPlot/commands/OneBlockCommand.java
@@ -21,8 +21,16 @@ public class OneBlockCommand implements CommandExecutor {
             return true;
         }
 
-        if (args.length > 0 && args[0].equalsIgnoreCase("home")) {
-            manager.teleportHome(p);
+        if (args.length > 0) {
+            if (args[0].equalsIgnoreCase("home")) {
+                manager.teleportHome(p);
+            } else if (args[0].equalsIgnoreCase("progress")) {
+                manager.sendProgress(p);
+            } else if (args[0].equalsIgnoreCase("phases")) {
+                manager.listPhases(p);
+            } else {
+                manager.startIsland(p);
+            }
         } else {
             manager.startIsland(p);
         }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,8 +6,8 @@ author: AJgorEx
 description: Zaawansowany plugin OneBlock z własnym światem, bossbarem i fazami
 commands:
   oneblock:
-    description: Tworzy wyspę OneBlock lub teleportuje na nią
-    usage: /oneblock
+    description: Tworzy wyspę OneBlock, teleportuje na nią i wyświetla informacje
+    usage: /oneblock [home|progress|phases]
     aliases: [ob, startblock]
 permissions:
   oneblock.use:


### PR DESCRIPTION
## Summary
- display phase info with `/oneblock progress`
- list all phases with `/oneblock phases`
- update plugin description and usage

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68449af7f43c8325a0d8c035e4a26c9a