### PR TITLE
Expand OneBlock commands

### DIFF
--- a/src/main/java/com/AJgorEx/xFlyPlot/OneBlockManager.java
+++ b/src/main/java/com/AJgorEx/xFlyPlot/OneBlockManager.java
@@ -130,6 +130,11 @@ public class OneBlockManager {
         }
     }
 
+    public void reloadPhases() {
+        phases.clear();
+        loadPhases();
+    }
+
     public Phase getCurrentPhase(int blocksBroken) {
         int sum = 0;
         for (Phase phase : phases) {

--- a/src/main/java/com/AJgorEx/xFlyPlot/commands/OneBlockCommand.java
+++ b/src/main/java/com/AJgorEx/xFlyPlot/commands/OneBlockCommand.java
@@ -1,6 +1,8 @@
 package com.AJgorEx.xFlyPlot.commands;
 
 import com.AJgorEx.xFlyPlot.OneBlockManager;
+import com.AJgorEx.xFlyPlot.Phase;
+import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -22,19 +24,38 @@ public class OneBlockCommand implements CommandExecutor {
         }
 
         if (args.length > 0) {
-            if (args[0].equalsIgnoreCase("home")) {
-                manager.teleportHome(p);
-            } else if (args[0].equalsIgnoreCase("progress")) {
-                manager.sendProgress(p);
-            } else if (args[0].equalsIgnoreCase("phases")) {
-                manager.listPhases(p);
-            } else {
-                manager.startIsland(p);
+            switch (args[0].toLowerCase()) {
+                case "home" -> manager.teleportHome(p);
+                case "progress" -> manager.sendProgress(p);
+                case "phases" -> manager.listPhases(p);
+                case "reset" -> {
+                    manager.removePlayer(p.getUniqueId());
+                    p.sendMessage(ChatColor.YELLOW + "Twoja wyspa zostala zresetowana.");
+                }
+                case "phase" -> {
+                    Phase phase = manager.getPlayerPhase(p.getUniqueId());
+                    p.sendMessage(ChatColor.YELLOW + "Aktualna faza: " + ChatColor.GOLD + phase.getName());
+                }
+                case "reload" -> {
+                    if (p.hasPermission("oneblock.reload")) {
+                        manager.reloadPhases();
+                        p.sendMessage(ChatColor.GREEN + "Przeladowano konfiguracje faz.");
+                    } else {
+                        p.sendMessage(ChatColor.RED + "Nie masz uprawnien.");
+                    }
+                }
+                case "help" -> sendHelp(p);
+                default -> manager.startIsland(p);
             }
         } else {
             manager.startIsland(p);
         }
 
         return true;
+    }
+
+    private void sendHelp(Player player) {
+        player.sendMessage(ChatColor.YELLOW + "Uzycie: /oneblock <subkomenda>");
+        player.sendMessage(ChatColor.GRAY + "home, progress, phases, phase, reset, reload, help");
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -7,9 +7,12 @@ description: Zaawansowany plugin OneBlock z własnym światem, bossbarem i fazam
 commands:
   oneblock:
     description: Tworzy wyspę OneBlock, teleportuje na nią i wyświetla informacje
-    usage: /oneblock [home|progress|phases]
+    usage: /oneblock [home|progress|phases|phase|reset|reload|help]
     aliases: [ob, startblock]
 permissions:
   oneblock.use:
     description: Pozwala na używanie komendy /oneblock
     default: true
+  oneblock.reload:
+    description: Pozwala na przeładowanie pliku phases.yml
+    default: op


### PR DESCRIPTION
## Summary
- add new subcommands (phase, reset, reload, help)
- reload phases without restart
- update plugin.yml with new usage and permission

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68449e20d69c8325b5e631915680809a