### PR TITLE
Fix teleport and add island delete option

### DIFF
--- a/src/main/java/com/AJgorEx/xFlyPlot/Main.java
+++ b/src/main/java/com/AJgorEx/xFlyPlot/Main.java
@@ -4,6 +4,7 @@ import com.AJgorEx.xFlyPlot.commands.OneBlockCommand;
 import com.AJgorEx.xFlyPlot.listeners.BlockBreakListener;
 import com.AJgorEx.xFlyPlot.listeners.VoidFallListener;
 import com.AJgorEx.xFlyPlot.listeners.MenuListener;
+import com.AJgorEx.xFlyPlot.listeners.GeneratorInteractListener;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public class Main extends JavaPlugin {
@@ -12,11 +13,13 @@ public class Main extends JavaPlugin {
 
     @Override
     public void onEnable() {
+        saveDefaultConfig();
         manager = new OneBlockManager(this);
         getCommand("oneblock").setExecutor(new OneBlockCommand(manager));
         getServer().getPluginManager().registerEvents(new BlockBreakListener(manager), this);
         getServer().getPluginManager().registerEvents(new VoidFallListener(manager), this);
         getServer().getPluginManager().registerEvents(new MenuListener(manager), this);
+        getServer().getPluginManager().registerEvents(new GeneratorInteractListener(manager), this);
         getLogger().info("xFlyPlot enabled.");
     }
 

--- a/src/main/java/com/AJgorEx/xFlyPlot/commands/OneBlockCommand.java
+++ b/src/main/java/com/AJgorEx/xFlyPlot/commands/OneBlockCommand.java
@@ -30,10 +30,7 @@ public class OneBlockCommand implements CommandExecutor {
                 case "phases" -> manager.listPhases(p);
                 case "menu" -> manager.openMenu(p);
                 case "start" -> manager.startIsland(p);
-                case "reset" -> {
-                    manager.removePlayer(p.getUniqueId());
-                    p.sendMessage(ChatColor.YELLOW + "Twoja wyspa zostala zresetowana.");
-                }
+                case "delete" -> manager.deleteIsland(p);
                 case "phase" -> {
                     Phase phase = manager.getPlayerPhase(p.getUniqueId());
                     p.sendMessage(ChatColor.YELLOW + "Aktualna faza: " + ChatColor.GOLD + phase.getName());
@@ -58,6 +55,6 @@ public class OneBlockCommand implements CommandExecutor {
 
     private void sendHelp(Player player) {
         player.sendMessage(ChatColor.YELLOW + "Uzycie: /oneblock <subkomenda>");
-        player.sendMessage(ChatColor.GRAY + "menu, start, home, progress, phases, phase, reset, reload, help");
+        player.sendMessage(ChatColor.GRAY + "menu, start, home, progress, phases, phase, delete, reload, help");
     }
 }

--- a/src/main/java/com/AJgorEx/xFlyPlot/listeners/GeneratorInteractListener.java
+++ b/src/main/java/com/AJgorEx/xFlyPlot/listeners/GeneratorInteractListener.java
@@ -1,0 +1,29 @@
+package com.AJgorEx.xFlyPlot.listeners;
+
+import com.AJgorEx.xFlyPlot.OneBlockManager;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.EquipmentSlot;
+
+public class GeneratorInteractListener implements Listener {
+    private final OneBlockManager manager;
+
+    public GeneratorInteractListener(OneBlockManager manager) {
+        this.manager = manager;
+    }
+
+    @EventHandler
+    public void onInteract(PlayerInteractEvent event) {
+        if (event.getAction() != Action.RIGHT_CLICK_BLOCK) return;
+        if (event.getHand() != EquipmentSlot.HAND) return;
+        if (!(event.getPlayer() instanceof Player player)) return;
+        if (event.getClickedBlock() == null) return;
+        if (!manager.isIslandBlock(player, event.getClickedBlock().getLocation())) return;
+
+        event.setCancelled(true);
+        manager.openMenu(player);
+    }
+}

--- a/src/main/java/com/AJgorEx/xFlyPlot/listeners/MenuListener.java
+++ b/src/main/java/com/AJgorEx/xFlyPlot/listeners/MenuListener.java
@@ -29,10 +29,7 @@ public class MenuListener implements Listener {
             case OAK_DOOR -> manager.teleportHome(player);
             case EXPERIENCE_BOTTLE -> manager.sendProgress(player);
             case BOOK -> manager.listPhases(player);
-            case BARRIER -> {
-                manager.removePlayer(player.getUniqueId());
-                player.sendMessage(ChatColor.YELLOW + "Twoja wyspa zostala zresetowana.");
-            }
+            case BARRIER -> manager.deleteIsland(player);
         }
 
         player.closeInventory();

--- a/src/main/java/com/AJgorEx/xFlyPlot/listeners/VoidFallListener.java
+++ b/src/main/java/com/AJgorEx/xFlyPlot/listeners/VoidFallListener.java
@@ -19,7 +19,7 @@ public class VoidFallListener implements Listener {
         if (event.getEntity() instanceof Player player &&
                 event.getCause() == EntityDamageEvent.DamageCause.VOID) {
             event.setCancelled(true);
-            player.teleport(manager.getGenerator(player.getUniqueId()));
+            player.teleport(manager.getGenerator(player.getUniqueId()).clone().add(0.5, 1, 0.5));
         }
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,9 @@
+# Default configuration for xFlyPlot
+world-prefix: xflyplot-
+# Sound names can be changed
+sounds:
+  start: ENTITY_PLAYER_LEVELUP
+  teleport: ENTITY_ENDERMAN_TELEPORT
+  phase-complete: UI_TOAST_CHALLENGE_COMPLETE
+  island-delete: ENTITY_WITHER_DEATH
+  bonus: ENTITY_EXPERIENCE_ORB_PICKUP

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -7,7 +7,7 @@ description: Zaawansowany plugin OneBlock z własnym światem, bossbarem i fazam
 commands:
   oneblock:
     description: Tworzy wyspę OneBlock, teleportuje na nią i wyświetla informacje
-    usage: /oneblock [menu|start|home|progress|phases|phase|reset|reload|help]
+    usage: /oneblock [menu|start|home|progress|phases|phase|delete|reload|help]
     aliases: [ob, startblock]
 permissions:
   oneblock.use:


### PR DESCRIPTION
## Summary
- fix imports in `OneBlockManager`
- add configurable sounds and world prefix
- fix teleport location after falling into void
- add island delete command and GUI option
- play sounds for major actions
- open GUI on right-clicking the generator
- include editable `config.yml` and `phases.yml`

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_6844c33d120c8325aa94ac5817aaade1