### PR TITLE
Expand dashboard and scoring

### DIFF
--- a/src/main/java/com/AJgorEx/xFlyPlot/Main.java
+++ b/src/main/java/com/AJgorEx/xFlyPlot/Main.java
@@ -26,6 +26,13 @@ public class Main extends JavaPlugin {
         getLogger().info("xFlyPlot enabled.");
     }
 
+    @Override
+    public void onDisable() {
+        if (manager != null) {
+            manager.clearAll();
+        }
+    }
+
     public OneBlockManager getOneBlockManager() {
         return manager;
     }

--- a/src/main/java/com/AJgorEx/xFlyPlot/listeners/BlockPlaceListener.java
+++ b/src/main/java/com/AJgorEx/xFlyPlot/listeners/BlockPlaceListener.java
@@ -17,7 +17,7 @@ public class BlockPlaceListener implements Listener {
     public void onBlockPlace(BlockPlaceEvent event) {
         Player player = event.getPlayer();
         if (manager.isPlayerIslandWorld(player, event.getBlock().getWorld())) {
-            manager.addIslandPoint(player.getUniqueId());
+            manager.addIslandPoint(player.getUniqueId(), event.getBlockPlaced().getType());
         }
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -13,3 +13,11 @@ sounds:
   phase-complete: UI_TOAST_CHALLENGE_COMPLETE
   island-delete: ENTITY_WITHER_DEATH
   bonus: ENTITY_EXPERIENCE_ORB_PICKUP
+
+# Points awarded for placing blocks. Material names follow Bukkit enum names.
+# 'default' value is used when a material is not listed.
+block-points:
+  default: 1
+  diamond_block: 5
+  gold_block: 3
+  iron_block: 2

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -12,23 +12,36 @@
 </style>
 </head>
 <body>
-<div class="glass">
+<div class="glass" id="info">
   <h1>OneBlock Leaderboard</h1>
   <table id="board">
     <thead><tr><th>Player</th><th>Level</th><th>Points</th></tr></thead>
     <tbody></tbody>
   </table>
+  <div id="server" style="margin-top:10px;font-size:14px;"></div>
 </div>
 <script>
-fetch('/stats').then(r=>r.json()).then(data=>{
+function updateBoard(data){
   const tbody=document.querySelector('#board tbody');
+  tbody.innerHTML='';
   data.sort((a,b)=>b.points-a.points);
   data.forEach(e=>{
     const row=document.createElement('tr');
-    row.innerHTML=`<td>${e.name}</td><td>${e.level}</td><td>${e.points}</td>`;
+    const avatar=`<img src="https://crafatar.com/avatars/${e.uuid}?size=32" style="vertical-align:middle;border-radius:4px;margin-right:5px">`;
+    row.innerHTML=`<td>${avatar}${e.name}</td><td>${e.level}</td><td>${e.points}</td>`;
     tbody.appendChild(row);
   });
-});
+}
+function updateServer(data){
+  const div=document.getElementById('server');
+  if(!data) return;
+  div.textContent=`Online: ${data.online} | Islands: ${data.islands} | Version: ${data.version}`;
+}
+function refresh(){
+  fetch('/stats').then(r=>r.json()).then(updateBoard);
+  fetch('/server').then(r=>r.json()).then(updateServer);
+}
+setInterval(refresh,5000);refresh();
 </script>
 </body>
 </html>

--- a/web/server.js
+++ b/web/server.js
@@ -4,6 +4,7 @@ const path = require('path');
 
 const app = express();
 const dataFile = path.join(__dirname, '../build/resources/main/stats.json');
+const infoFile = path.join(__dirname, '../build/resources/main/server.json');
 
 app.use(express.static(path.join(__dirname, 'public')));
 
@@ -11,6 +12,13 @@ app.get('/stats', (req, res) => {
   fs.readFile(dataFile, 'utf8', (err, data) => {
     if (err) return res.json([]);
     try { res.json(JSON.parse(data)); } catch (e) { res.json([]); }
+  });
+});
+
+app.get('/server', (req, res) => {
+  fs.readFile(infoFile, 'utf8', (err, data) => {
+    if (err) return res.json({});
+    try { res.json(JSON.parse(data)); } catch (e) { res.json({}); }
   });
 });
 


### PR DESCRIPTION
## Summary
- enable custom block scoring and save player sessions
- store server stats for the web dashboard
- add avatar support and auto refresh to dashboard

## Testing
- `gradle build`
- `npm install --silent`

------
https://chatgpt.com/codex/tasks/task_e_6844ceaaa3b08325857ef86f8d954ee7